### PR TITLE
Clap fixes for the "run" command

### DIFF
--- a/xc-bin/src/run.rs
+++ b/xc-bin/src/run.rs
@@ -73,12 +73,15 @@ impl DnsArgs {
 }
 
 #[derive(Parser, Debug)]
+pub(crate) struct PublishArgs {
+    #[arg(long = "publish", short = 'p')]
+    pub(crate) publish: Vec<PublishSpec>,
+}
+
+#[derive(Parser, Debug)]
 pub(crate) struct RunArg {
     #[arg(long = "link", action)]
     pub(crate) link: bool,
-
-    #[arg(long = "publish", short = 'p', /* multiple_occurrences */)]
-    pub(crate) publish: Vec<PublishSpec>,
 
     #[arg(long = "detach", short = 'd', action)]
     pub(crate) detach: bool,
@@ -128,9 +131,6 @@ pub(crate) struct CreateArgs {
 
     #[arg(long = "extra-layer", /* multiple_occurrences */)]
     pub(crate) extra_layers: Vec<PathBuf>,
-
-    #[arg(long = "publish", short = 'p', /* multiple_occurrences */)]
-    pub(crate) publish: Vec<PublishSpec>,
 
     pub(crate) image_reference: ImageReference,
 

--- a/xc-bin/src/run.rs
+++ b/xc-bin/src/run.rs
@@ -89,7 +89,7 @@ pub(crate) struct RunArg {
     #[arg(long = "user", short = 'u', action)]
     pub(crate) user: Option<String>,
 
-    #[arg(long = "group", short = 'u', action)]
+    #[arg(long = "group", short = 'g', action)]
     pub(crate) group: Option<String>,
 
     pub(crate) entry_point: Option<String>,


### PR DESCRIPTION
The command "run" will panic in Debug mode due to some inconsistencies with the Clap configuration.

The first issue is that the "publish" argument is shared between "create" and "run" and, as they are flattened in the enum `Action`, clap will complain they are not unique.

The second issue is probably a typo. The short name "u" is used by the "user" and "group" arguments in the `RunArg` struct.

My Rust still needs some oxidation so there might be a better solution for that :)