### PR TITLE
xc: handle kevent syscall interruption

### DIFF
--- a/xc/src/container/runner/mod.rs
+++ b/xc/src/container/runner/mod.rs
@@ -600,8 +600,17 @@ impl ProcessRunner {
                 self.send_update(&mut sender);
             }
 
-            let nevx = kevent_ts(kq, &[], &mut events, None);
-            let nev = nevx.unwrap();
+            let nev = match kevent_ts(kq, &[], &mut events, None) {
+                Ok(value) => value,
+                Err(value) => {
+                    if value == nix::errno::Errno::EINTR {
+                        continue;
+                    } else {
+                        panic!("kevent_ts error: {}", value);
+                    }
+                }
+            };
+
 
             for event in &events[..nev] {
                 match event.filter().unwrap() {


### PR DESCRIPTION
kevent will be interrupted and return EINTR on the arrival of a signal. When calling truss for example against the xcd child process that is handling the container it will crash because the kevent_ts will return Err and unwrap() is immediately called on it.

Check if kevent_ts failed and restart the loop if it failed due to a EINTR, panic! otherwise.